### PR TITLE
Fix: Removes redundant status from buttons (Fixes #30)

### DIFF
--- a/templates/partials/pageNav-item.hbs
+++ b/templates/partials/pageNav-item.hbs
@@ -7,7 +7,7 @@
   data-id="{{_id}}"
   data-item-index="{{_index}}"
   {{#any _isHidden locked}} disabled="disabled"{{/any}}
-  aria-label="{{{compile ariaLabel this}}} {{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}{{else if _isComplete}}{{@root/_globals._accessibility._ariaLabels.complete}}{{else}}{{@root/_globals._accessibility._ariaLabels.incomplete}}{{/if}}"
+  aria-label="{{{compile ariaLabel this}}}; {{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}{{/if}}"
   data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}">
 
   <span class="pagenav__btn-inner">

--- a/templates/partials/pageNav-item.hbs
+++ b/templates/partials/pageNav-item.hbs
@@ -7,7 +7,7 @@
   data-id="{{_id}}"
   data-item-index="{{_index}}"
   {{#any _isHidden locked}} disabled="disabled"{{/any}}
-  aria-label="{{{compile ariaLabel this}}}; {{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}{{/if}}"
+  aria-label="{{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}. {{/if}}{{{compile ariaLabel this}}}"
   data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}">
 
   <span class="pagenav__btn-inner">


### PR DESCRIPTION
We previously discussed how the status text in the aria-label is redundant information and learners would know the aria label & status of the menu/page once they reach it.