### PR TITLE
Update: Highlight current page (fixes #18)

### DIFF
--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -30,7 +30,7 @@ html {
     margin: @item-margin;
 
     &[aria-current="page"] {
-      // TODO: put button styles for current page here
+      background-color: darken(@btn-item-color, 20%);
     }
   }
 

--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -28,6 +28,10 @@ html {
 .pagenav {
   &__btn {
     margin: @item-margin;
+
+    &[aria-current="page"] {
+      // TODO: put button styles for current page here
+    }
   }
 
   // buttons with text and icon (left aligned icon as default)

--- a/templates/partials/pageNav-item.hbs
+++ b/templates/partials/pageNav-item.hbs
@@ -8,7 +8,7 @@
   data-item-index="{{_index}}"
   {{#any _isHidden locked}} disabled="disabled"{{/any}}
   aria-label="{{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}. {{/if}}{{{compile ariaLabel this}}}"
-  data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}">
+  data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}" aria-current="{{#if isCurrent }}page{{else}}false{{/if}}">
 
   <span class="pagenav__btn-inner">
 


### PR DESCRIPTION
fixes #18 

### Update

* Added `aria-current="page"` to nav button representing current page.
* Added stub ruleset to pageNav.less where styles can be added for this button.

Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current