### PR TITLE
Fix: Icon misalignment (fixes #36)

### DIFF
--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -32,10 +32,6 @@ html {
 
   &__btn-icon {
     display: inline-flex;
-
-    .icon {
-      display: inline-flex;
-    }
   }
 
   // buttons with text and icon (left aligned icon as default)

--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -30,8 +30,8 @@ html {
     margin: @item-margin;
   }
 
-  &__btn-icon {
-    display: inline-flex;
+  &__btn-icon .icon {
+    display: block;
   }
 
   // buttons with text and icon (left aligned icon as default)

--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -30,6 +30,14 @@ html {
     margin: @item-margin;
   }
 
+  &__btn-icon {
+    display: inline-flex;
+
+    .icon {
+      display: inline-flex;
+    }
+  }
+
   // buttons with text and icon (left aligned icon as default)
   // --------------------------------------------------
   &__btn.btn-icon:not(.icon-is-right).btn-text .icon {

--- a/templates/partials/pageNav-item.hbs
+++ b/templates/partials/pageNav-item.hbs
@@ -14,7 +14,7 @@
 
     {{#unless _alignIconRight}}
     {{#if _iconClass}}
-    <span class="pagenav__btn-icon">
+    <span class="pagenav__btn-icon" aria-hidden="true">
       <span class="icon {{_iconClass}}"></span>
     </span>
     {{/if}}
@@ -30,7 +30,7 @@
 
     {{#if _alignIconRight}}
     {{#if _iconClass}}
-    <span class="pagenav__btn-icon">
+    <span class="pagenav__btn-icon" aria-hidden="true">
       <span class="icon {{_iconClass}}"></span>
     </span>
     {{/if}}


### PR DESCRIPTION
Fixes #36 

### Changes

- Changes display of both `.pagenav__btn-icon` and the child `.icon` element to inline-flex.