### PR TITLE
Fix: Fix isCurrent property and button color variable (fixes #46)

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -1,7 +1,8 @@
 define([
   'core/js/adapt',
+  'core/js/location',
   'core/js/models/componentModel'
-], function(Adapt, ComponentModel) {
+], function(Adapt, Location, ComponentModel) {
 
   var Model = ComponentModel.extend({
 
@@ -65,6 +66,7 @@ top.window.close();
             _.extend(item, buttonConfig, {
               type: attrName,
               index: index,
+              isCurrent: item._id === Location._currentId,
               order: order++,
               locked: item._isLocked || (buttonConfig._lockUntilPageComplete && !currentPageComplete)
             });

--- a/js/model.js
+++ b/js/model.js
@@ -66,7 +66,7 @@ top.window.close();
             _.extend(item, buttonConfig, {
               type: attrName,
               index: index,
-              isCurrent: item._id === Location._currentId,
+              _isCurrent: item._id === Location._currentId,
               order: order++,
               locked: item._isLocked || (buttonConfig._lockUntilPageComplete && !currentPageComplete)
             });

--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -30,7 +30,7 @@ html {
     margin: @item-margin;
 
     &[aria-current="page"] {
-      background-color: darken(@btn-item-color, 20%);
+      background-color: darken(@btn-color, 20%);
     }
   }
 

--- a/templates/partials/pageNav-item.hbs
+++ b/templates/partials/pageNav-item.hbs
@@ -8,7 +8,7 @@
   data-item-index="{{_index}}"
   {{#any _isHidden locked}} disabled="disabled"{{/any}}
   aria-label="{{#if locked}}{{@root/_globals._accessibility._ariaLabels.locked}}. {{/if}}{{{compile ariaLabel this}}}"
-  data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}" aria-current="{{#if isCurrent }}page{{else}}false{{/if}}">
+  data-tooltip="{{#if _showTooltip}}{{{compile tooltip this}}}{{/if}}" aria-current="{{#if _isCurrent }}page{{else}}false{{/if}}">
 
   <span class="pagenav__btn-inner">
 


### PR DESCRIPTION
Fixes #46 

### Fix
* Fixes `isCurrent` property and changes name to `_isCurrent`
* Fixes `@btn-item-color` variable - replace with `@btn-color`

### Testing
1. Add Page Nav components to each page in a course
2. Change `_sibling._isEnabled` to 'true' to get the numbered pagination buttons

### Expectation
The current page's numbered button should be darker than the other buttons.

