### PR TITLE
Fix: Restore _returnToPreviousLocation option (fix #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Navigation bar component which can contain some or all of the following buttons:
 
 - `_root`: Navigates to the top level menu
 - `_up`: Navigates to the menu that is the next level up in the hierarchy. For instance, a sub menu.
+- `_returnToPreviousLocation`: Navigates to the previous location. For example, if the user navigates to a help page that is not part of the normal flow, this would take them back to the previous page that they visited
 - `_previous`: Navigates to the previous page if it exists and is unlocked
 - `_next`: Navigates to the next page if it exists and is unlocked
 - `_close`: Closes the course window. Only possible if the course was launched in a popup window
@@ -34,13 +35,14 @@ The **PageNav** buttons will respect any [locking](https://github.com/adaptlearn
 **instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.
 
 **\_loopStyle** (string): Acceptable values are `allPages`, `siblings`, and `none`. Defaults to `none`.
+
 - `allPages`: Loop sequentially through all pages in course
 - `siblings`: Loop sequentially through all pages in current parent object
 - `none`: Disable previous and next buttons at start and end of the pages in the current parent object.
 
 **\_shouldSkipOptionalPages** (boolean): Skip pages that are set to `"_isOptional": true`. Default is `false`.
 
-**\_buttons** (object): The following attributes configure the defaults for the **Quickanv** buttons. These attributes are available on all of the following buttons **\_previous**, **\_root**, **\_up**, **\_next**, and **\_close**.
+**\_buttons** (object): The following attributes configure the defaults for the **Page Nav** buttons. These attributes are available on all of the following buttons: **\_root**, **\_up**, **\_returnToPreviousLocation**, **\_previous**, **\_next**, and **\_close**.
 
 #### Global button configurations
 
@@ -72,7 +74,6 @@ The **PageNav** buttons will respect any [locking](https://github.com/adaptlearn
 
 ----------------------------
 
-**Framework versions:**  5.30.2+<br>
 **Vanilla versions:**  5.1.1+<br>
 **Author / maintainer:**  Kineo<br>
 **Accessibility support:**  WAI AA<br>

--- a/example.json
+++ b/example.json
@@ -49,6 +49,20 @@
             },
             "_customRouteId": ""
         },
+        "_returnToPreviousLocation": {
+            "_isEnabled": false,
+            "_lockUntilPageComplete": false,
+            "_order": 1,
+            "_classes": "",
+            "_iconClass": "icon-controls-left",
+            "_iconAlignment": "auto",
+            "text": "Return",
+            "ariaLabel": "Return to previous location",
+            "_tooltip": {
+                "_isEnabled": true,
+                "text": "{{displayTitle}}"
+            }
+        },
         "_previous": {
             "_isEnabled": true,
             "_lockUntilPageComplete": false,

--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -71,12 +71,19 @@ class PageNavModel extends ComponentModel {
     return {
       _page: this.getCurrentPage(),
       _up: this.getCurrentMenu(),
+      _returnToPreviousLocation: this.getReturnToPreviousLocation(),
       _root: Adapt.course,
       _next: this.getNextPage(),
       _previous: this.getPrevPage(),
       _close: this.getClose()
     };
   }
+
+  getReturnToPreviousLocation() {
+    if (!location._previousId) return;
+
+    return data.findById(location._previousId);
+  };
 
   getCurrentPage() {
     return location._currentModel;

--- a/properties.schema
+++ b/properties.schema
@@ -372,6 +372,103 @@
             }
           }
         },
+        "_returnToPreviousLocation": {
+          "type": "object",
+          "required": true,
+          "legend": "Return to previous location button",
+          "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "required": true,
+              "title": "Show",
+              "default": false,
+              "inputType": "Checkbox",
+              "validators": []
+            },
+            "_lockUntilPageComplete": {
+              "type": "boolean",
+              "required": true,
+              "title": "Lock until page complete",
+              "default": false,
+              "inputType": "Checkbox",
+              "validators": [],
+              "help": "For use when the standard Adapt locking system doesn't apply, such as in a start page before the main menu"
+            },
+            "_order": {
+              "type": "number",
+              "required": true,
+              "default": 0,
+              "title": "Order",
+              "inputType": "Number",
+              "validators": ["required", "number"],
+              "help": "Button display order"
+            },
+            "_classes": {
+              "type": "string",
+              "required": false,
+              "title": "Classes",
+              "default": "",
+              "inputType": "Text",
+              "validators": []
+            },
+            "_iconClass": {
+              "type": "string",
+              "required": false,
+              "title": "Icon class",
+              "default": "icon-controls-left",
+              "help": "CSS class name to be applied to the button icon. Suggested: icon-controls-left",
+              "inputType": "Text",
+              "validators": []
+            },
+            "_iconAlignment": {
+              "type": "string",
+              "required": false,
+              "default": "auto",
+              "inputType": {"type":"Select", "options":["auto","left","right","top","bottom"]},
+              "title": "Icon alignment",
+              "help": "Determines how the icon is aligned to the text."
+            },
+            "text": {
+              "type": "string",
+              "required": true,
+              "default": "Return",
+              "inputType": "Text",
+              "validators": [],
+              "translatable": true
+            },
+            "ariaLabel": {
+              "type": "string",
+              "required": true,
+              "title": "ARIA label",
+              "default": "Return to previous location",
+              "inputType": "Text",
+              "validators": [],
+              "translatable": true
+            },
+            "_navTooltip": {
+              "type": "object",
+              "title": "Navigation tooltip",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Enable tooltip for navigation button",
+                  "inputType": "Checkbox",
+                  "validators": []
+                },
+                "text": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Return to previous location",
+                  "help": "The tooltip text to display on hover over this item",
+                  "inputType": "Text",
+                  "validators": [],
+                  "translatable": true
+                }
+              }
+            }
+          }
+        },
         "_next": {
           "type": "object",
           "required": true,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -52,6 +52,7 @@
             "_previous",
             "_root",
             "_up",
+            "_returnToPreviousLocation",
             "_next",
             "_close"
           ],
@@ -328,6 +329,92 @@
                   "title": "Override the route id",
                   "description": "Enter the Friendly id of the page that the button should direct the user to. For use when non-standard navigation is required.",
                   "default": ""
+                }
+              }
+            },
+            "_returnToPreviousLocation": {
+              "type": "object",
+              "title": "Return to previous location button",
+              "description": "Navigates to the previous location. For example, if the user navigates to a help page that is not part of the normal flow, this would take them back to the previous page that they visited",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "title": "Show",
+                  "default": false
+                },
+                "_lockUntilPageComplete": {
+                  "type": "boolean",
+                  "title": "Lock until page complete",
+                  "description": "For use when the standard Adapt locking system doesn't apply, such as in a start page before the main menu",
+                  "default": false
+                },
+                "_order": {
+                  "type": "number",
+                  "title": "Order",
+                  "description": "Button display order",
+                  "default": 0
+                },
+                "_classes": {
+                  "type": "string",
+                  "title": "Classes",
+                  "default": ""
+                },
+                "_iconClass": {
+                  "type": "string",
+                  "title": "Icon class",
+                  "description": "CSS class name to be applied to the button icon. Suggested: icon-controls-left",
+                  "default": "icon-controls-left"
+                },
+                "_iconAlignment": {
+                  "type": "string",
+                  "title": "Icon alignment",
+                  "description": "Determines how the icon is aligned to the text.",
+                  "default": "auto",
+                  "enum": [
+                    "auto",
+                    "left",
+                    "right",
+                    "top",
+                    "bottom"
+                  ],
+                  "_backboneForms": "Select"
+                },
+                "text": {
+                  "type": "string",
+                  "title": "Button text",
+                  "description": "Text that appears on the button. Optional since you can only use an icon.",
+                  "default": "Return",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "ariaLabel": {
+                  "type": "string",
+                  "title": "ARIA label",
+                  "default": "Return to previous location",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "_navTooltip": {
+                  "type": "object",
+                  "title": "Button tooltip",
+                  "default": {},
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "title": "Enable tooltip for this button",
+                      "default": true
+                    },
+                    "text": {
+                      "type": "string",
+                      "title": "",
+                      "default": "Return to previous location",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
Fixes #55 

### Fix
* Restores the `_returnToPreviousLocation` option after it was removed in PR #49 
* Updates the description in the readme and schemas to better clarify the functionality. I do remember the team discussing that the current description was a tad confusing. Open to suggestions here, though.

### Testing
See _example.json_.


