### PR TITLE
Update: padlock replaces icon when button locked (#58)

### DIFF
--- a/less/pageNav.less
+++ b/less/pageNav.less
@@ -98,6 +98,12 @@
   }
 }
 
+// Padlock replaces icon when locked
+// --------------------------------------------------
+.pagenav__btn.is-locked .icon {
+  .icon-padlock-locked;
+}
+
 // Consistent with nav icon button styling
 // --------------------------------------------------
 .pagenav__btn.btn-icon:not(.btn-text) {


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-pageNav/issues/58

### Update
As per https://github.com/adaptlearning/adapt-contrib-vanilla/issues/446, locked disabled buttons should display a padlock icon.

### Testing
Add [example](https://github.com/cgkineo/adapt-pageNav/blob/master/example.json) to the end of your page in `component.json`.

Enable course locking, e.g. `"_lockType": "sequential"` in _course.json_.

When page is incomplete, the 'Next' button is locked and padlock icon is displayed.
![next_page_locked](https://github.com/cgkineo/adapt-pageNav/assets/7045330/e7207a81-82fc-49bb-9889-fcc009a3fa99)

When page is complete, the 'Next' button is active and the default chevron icon is displayed.
![next_page_unlocked](https://github.com/cgkineo/adapt-pageNav/assets/7045330/f8843fac-25b8-451d-850f-6bf20137f877)
