### PR TITLE
Fix: Check if content object(page) is set to _isOptional and unlock pageNav button if set to _lockUntilPageComplete (fixes #64)

### DIFF
--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -58,7 +58,7 @@ class PageNavModel extends ComponentModel {
         index: 0,
         order: order++,
         _tooltipId: `pagenav_btn${type}`,
-        locked: (item._isLocked && !currentPageOptional) || ((buttonConfig._lockUntilPageComplete && !currentPageComplete) && !currentPageOptional) 
+        locked: !currentPageOptional && (item._isLocked || (buttonConfig._lockUntilPageComplete && !currentPageComplete)) 
       });
       unsortedItems.push(item);
     }

--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -30,6 +30,7 @@ class PageNavModel extends ComponentModel {
 
     const buttonTypeModels = this.getButtonTypeModels();
     const currentPageComplete = buttonTypeModels._page.get('_isComplete');
+    const currentPageOptional = buttonTypeModels._page.get('_isOptional');
     const unsortedItems = [];
     let order = 0;
     let item;
@@ -57,7 +58,7 @@ class PageNavModel extends ComponentModel {
         index: 0,
         order: order++,
         _tooltipId: `pagenav_btn${type}`,
-        locked: item._isLocked || (buttonConfig._lockUntilPageComplete && !currentPageComplete)
+        locked: (item._isLocked && !currentPageOptional) || ((buttonConfig._lockUntilPageComplete && !currentPageComplete) && !currentPageOptional) 
       });
       unsortedItems.push(item);
     }


### PR DESCRIPTION
Fixes #64 

### Fix
Checks if content object(page) is set to _isOptional and automatically unlocks the pageNav buttons  to _lockUntilPageComplete 

### Testing
1. Install the diagnostic plug-in or set the Content Object to _isOptional
2. Configure pageNav to _lockUntilPageComplete




