### PR TITLE
Fix: Prevent _customRouteId from being ignored, allow hidden content objects (fixes #68 #69)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -43,11 +43,12 @@ class PageNavModel extends ComponentModel {
 
       // Get models, skipping any undefined types (ex. deprecated button types)
       let buttonModel = buttonTypeModels[type];
-      if (!buttonModel) continue;
+      if (!buttonModel && !buttonConfig._customRouteId) continue;
 
       // Find buttonModel from config._customRouteId if not found in defined type
       if (buttonConfig._customRouteId) {
         buttonModel = data.findById(buttonConfig._customRouteId);
+        if (!buttonModel) continue;
       }
 
       // Convert found buttonModel to json if exists or create an 'undefined' json

--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -42,14 +42,12 @@ class PageNavModel extends ComponentModel {
       if (!buttonConfig._isEnabled) continue;
 
       // Get models, skipping any undefined types (ex. deprecated button types)
-      let buttonModel = buttonTypeModels[type];
-      if (!buttonModel && !buttonConfig._customRouteId) continue;
-
       // Find buttonModel from config._customRouteId if not found in defined type
-      if (buttonConfig._customRouteId) {
-        buttonModel = data.findById(buttonConfig._customRouteId);
-        if (!buttonModel) continue;
-      }
+      const buttonModel = buttonConfig._customRouteId
+        ? data.findById(buttonConfig._customRouteId)
+        : buttonTypeModels[type];
+
+      if (!buttonModel) continue;
 
       // Convert found buttonModel to json if exists or create an 'undefined' json
       item = buttonModel ? buttonModel.toJSON() : { _isHidden: true };
@@ -107,8 +105,8 @@ class PageNavModel extends ComponentModel {
     let hasFoundCurrentPage = false;
 
     for (const page of pages.reverse()) {
-      const isNotAvailable = !page.get('_isAvailable');
-      if (isNotAvailable) continue;
+      const isNotShown = !page.get('_isAvailable') || page.get('_isHidden');
+      if (isNotShown) continue;
 
       if (!hasFoundCurrentPage) {
         hasFoundCurrentPage = page.get('_id') === currentPageId;
@@ -128,8 +126,8 @@ class PageNavModel extends ComponentModel {
     let hasFoundCurrentPage = false;
 
     for (const page of pages) {
-      const isNotAvailable = !page.get('_isAvailable');
-      if (isNotAvailable) continue;
+      const isNotShown = !page.get('_isAvailable') || page.get('_isHidden');
+      if (isNotShown) continue;
 
       if (!hasFoundCurrentPage) {
         hasFoundCurrentPage = page.get('_id') === currentPageId;

--- a/js/PageNavView.js
+++ b/js/PageNavView.js
@@ -42,9 +42,7 @@ class PageNavView extends ComponentView {
       return;
     }
 
-    // Check if locked
-    const isLocked = item._isHidden || item._isLocked;
-    if (isLocked) return;
+    if (item._isLocked) return;
 
     this.navigateTo(item._id);
   };
@@ -67,7 +65,7 @@ class PageNavView extends ComponentView {
   setupTooltips() {
     const items = this.model.get('_items');
     items.forEach(item => {
-      if (!item._tooltip || item._isHidden) return;
+      if (!item._tooltip) return;
 
       tooltips.register({
         _id: item._tooltipId,

--- a/templates/pageNavItem.jsx
+++ b/templates/pageNavItem.jsx
@@ -11,7 +11,6 @@ export default function PageNavItem(props) {
     _iconClass,
     _id,
     _index,
-    _isHidden,
     _tooltipId,
     ariaLabel,
     locked,
@@ -27,9 +26,8 @@ export default function PageNavItem(props) {
         _iconClass && 'btn-icon has-icon',
         _iconAlignment && `has-icon-${_iconAlignment}`,
         text && 'btn-text has-text',
-        _isHidden && 'is-hidden',
         locked && 'is-locked',
-        (_isHidden || locked) && 'is-disabled',
+        locked && 'is-disabled',
         _classes
       ])}
       role="link"
@@ -37,7 +35,7 @@ export default function PageNavItem(props) {
       data-id={_id}
       data-item-index={_index}
       data-tooltip-id={_tooltipId}
-      disabled={_isHidden || locked}
+      disabled={locked}
       aria-label={`${locked ? globals._accessibility._ariaLabels.locked + '. ' : ''}${compile(ariaLabel, props)}`}
       onClick={onButtonClick}
     >


### PR DESCRIPTION
Fixes #68  #69 

### Fix
* Prevents `_customRouteId` from being ignored if a valid model wasn't first found for the button type
* Allow hidden content objects to be used in navigation
* Fix typo in PR template
