### PR TITLE
Fix: Ensure _customRouteId model is available before displaying button (fixes #71)

### DIFF
--- a/js/PageNavModel.js
+++ b/js/PageNavModel.js
@@ -44,7 +44,7 @@ class PageNavModel extends ComponentModel {
       // Get models, skipping any undefined types (ex. deprecated button types)
       // Find buttonModel from config._customRouteId if not found in defined type
       const buttonModel = buttonConfig._customRouteId
-        ? data.findById(buttonConfig._customRouteId)
+        ? this.getCustomRoutePage(buttonConfig._customRouteId)
         : buttonTypeModels[type];
 
       if (!buttonModel) continue;
@@ -138,6 +138,12 @@ class PageNavModel extends ComponentModel {
         return page;
       }
     }
+  }
+
+  getCustomRoutePage(id) {
+    const buttonModel = data.findById(id);
+    if (!buttonModel || !buttonModel.get('_isAvailable')) return;
+    return buttonModel;
   }
 
   getPages() {


### PR DESCRIPTION
Fix #71 

### Fix
* When using `_customRouteId`, ensure the content object model is available (`_isAvailable: true`). If not, do not display the button.
* This will still allow pages to be navigated to when they are hidden with `_isHidden: true`
