### PR TITLE
Fix: Override onInview function (fixes #76)

### DIFF
--- a/js/PageNavView.js
+++ b/js/PageNavView.js
@@ -25,6 +25,17 @@ class PageNavView extends ComponentView {
     this.setupTooltips();
   };
 
+  onInview(event, visible, visiblePartX, visiblePartY) {
+    if (!visible) return;
+    if (visiblePartY === 'top') this.hasSeenTop = true;
+    if (!this.hasSeenTop) return;
+
+    this.inviewCallback();
+
+    if (!this.model.get('_isComplete')) return;
+    this.removeInviewListener();
+  }
+
   onContentObjectComplete() {
     // Update model so that _lockUntilPageComplete works properly
     this.model.setupItemsModel();


### PR DESCRIPTION
Fixes: #76

### Fix
* Override onInview function within pageNav to set completion only to top
